### PR TITLE
Feat: Support for PGliteWorker as constructor argument for PGliteDialect. Closes #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "kysely-pglite",
-  "version": "1.0.0",
+  "name": "kysely-pglite-dialect",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "kysely-pglite",
-      "version": "1.0.0",
+      "name": "kysely-pglite-dialect",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@electric-sql/pglite": "^0.2.0",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,10 +1,11 @@
 import { CompiledQuery, DatabaseConnection, QueryResult } from "kysely"
 import { PGlite } from "@electric-sql/pglite"
+import { PGliteWorker } from "@electric-sql/pglite/worker"
 
 export class PGliteConnection implements DatabaseConnection {
-  private readonly client: PGlite
+  private readonly client: PGlite | PGliteWorker
 
-  constructor(client: PGlite) {
+  constructor(client: PGlite | PGliteWorker) {
     this.client = client
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,6 +1,6 @@
 import { CompiledQuery, DatabaseConnection, QueryResult } from "kysely"
 import { PGlite } from "@electric-sql/pglite"
-import { PGliteWorker } from "@electric-sql/pglite/worker"
+import type { PGliteWorker } from "@electric-sql/pglite/worker"
 
 export class PGliteConnection implements DatabaseConnection {
   private readonly client: PGlite | PGliteWorker

--- a/src/dialect.ts
+++ b/src/dialect.ts
@@ -12,10 +12,11 @@ import {
   TransactionSettings,
 } from "kysely"
 import { PGlite } from "@electric-sql/pglite"
+import { PGliteWorker } from "@electric-sql/pglite/worker"
 import { PGliteConnection } from "connection"
 
 export class PGliteDialect implements Dialect {
-  constructor(private readonly pgLite: PGlite) { }
+  constructor(private readonly pgLite: PGlite | PGliteWorker) { }
 
   createAdapter() {
     return new PostgresAdapter()
@@ -35,7 +36,7 @@ export class PGliteDialect implements Dialect {
 }
 
 class PGliteDriver implements Driver {
-  private client: PGlite | undefined
+  private client: PGlite | PGliteWorker | undefined
   /**
    * Currently used connection.
    * If another acquireConnection() is called the request is queued till this connection has been released.
@@ -43,7 +44,7 @@ class PGliteDriver implements Driver {
   private connection: PGliteConnection | undefined;
   private queue: ((con: PGliteConnection) => void)[] = [];
 
-  constructor(pgLite: PGlite) {
+  constructor(pgLite: PGlite | PGliteWorker) {
     this.client = pgLite
   }
 

--- a/src/dialect.ts
+++ b/src/dialect.ts
@@ -12,7 +12,7 @@ import {
   TransactionSettings,
 } from "kysely"
 import { PGlite } from "@electric-sql/pglite"
-import { PGliteWorker } from "@electric-sql/pglite/worker"
+import type { PGliteWorker } from "@electric-sql/pglite/worker"
 import { PGliteConnection } from "connection"
 
 export class PGliteDialect implements Dialect {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
     "noEmit": true,
     "incremental": false,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "baseUrl": "./src"


### PR DESCRIPTION
Apart from introducing `PGliteWorker` to connection, driver and dialect, I also had to configure `moduleResolution` in tsconfig so that I could import `PGliteWorker` from worker module of `@electirc-sql/pglite` package.