### PR TITLE
Remove numUpdatedOrDeletedRows

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -17,7 +17,6 @@ export class PGliteConnection implements DatabaseConnection {
     if (result.affectedRows) {
       const numAffectedRows = BigInt(result.affectedRows)
       return {
-        numUpdatedOrDeletedRows: numAffectedRows,
         numAffectedRows,
         rows: result.rows as O[],
       }


### PR DESCRIPTION
This module is great! Though I'm seeing a bunch of these warnings:

```
kysely:warning: outdated driver/plugin detected! `QueryResult.numUpdatedOrDeletedRows` has been replaced with `QueryResult.numAffectedRows`.
```

...which seems to come from here: https://github.com/kysely-org/kysely/blob/5647fe36f5ba79fb95363d4b13cdb18499636f65/src/query-executor/query-executor-base.ts#L67-L71

Removing this key makes the deprecation warnings go away.